### PR TITLE
Add mouse wheel zoom in PDF splitter preview

### DIFF
--- a/src/ui/pdf_splitter.py
+++ b/src/ui/pdf_splitter.py
@@ -1,10 +1,11 @@
 from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, 
-    QSpinBox, QScrollArea, QFileDialog, QMessageBox, QGridLayout
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QSpinBox, QFileDialog, QMessageBox, QGridLayout
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QImage, QPixmap
 from ..utils.pdf_handler import PDFHandler
+from .zoomable_scroll_area import ZoomableScrollArea
 import fitz
 import os
 
@@ -96,7 +97,7 @@ class PDFSplitterWidget(QWidget):
         preview_label.setAlignment(Qt.AlignCenter)
         
         # 미리보기 스크롤 영역
-        self.scroll_area = QScrollArea()
+        self.scroll_area = ZoomableScrollArea(self.zoom_spin)
         self.scroll_area.setWidgetResizable(True)
         self.scroll_area.setMinimumWidth(400)
         

--- a/src/ui/zoomable_scroll_area.py
+++ b/src/ui/zoomable_scroll_area.py
@@ -1,0 +1,26 @@
+from PyQt5.QtWidgets import QScrollArea
+from PyQt5.QtCore import Qt
+
+class ZoomableScrollArea(QScrollArea):
+    """Scroll area that supports zooming with the mouse wheel.
+
+    If the Ctrl key is pressed while scrolling, the assigned spin box's value
+    will be changed, triggering any connected update logic (e.g. preview
+    refresh). Regular scrolling behaviour is preserved otherwise.
+    """
+    def __init__(self, zoom_spin, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._zoom_spin = zoom_spin
+
+    def wheelEvent(self, event):
+        if event.modifiers() & Qt.ControlModifier:
+            delta = event.angleDelta().y()
+            step = 5
+            if delta > 0:
+                new_val = min(self._zoom_spin.maximum(), self._zoom_spin.value() + step)
+            else:
+                new_val = max(self._zoom_spin.minimum(), self._zoom_spin.value() - step)
+            self._zoom_spin.setValue(new_val)
+            event.accept()
+        else:
+            super().wheelEvent(event)


### PR DESCRIPTION
## Summary
- create `ZoomableScrollArea` for Ctrl+wheel zoom handling
- use `ZoomableScrollArea` in PDF splitter preview panel

## Testing
- `python -m py_compile src/ui/zoomable_scroll_area.py src/ui/pdf_splitter.py`
- `python -m py_compile $(git ls-files '*.py')`