### PR TITLE
Enable Ctrl+wheel zoom across PDF previews

### DIFF
--- a/src/ui/pdf_formula_extractor.py
+++ b/src/ui/pdf_formula_extractor.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, 
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel,
     QPushButton, QFileDialog, QMessageBox, QListWidget,
-    QTextEdit, QComboBox, QSpinBox, QCheckBox, QApplication, QScrollArea
+    QTextEdit, QComboBox, QSpinBox, QCheckBox, QApplication
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QClipboard

--- a/src/ui/pdf_rotator.py
+++ b/src/ui/pdf_rotator.py
@@ -1,10 +1,11 @@
 from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, 
-    QFileDialog, QMessageBox, QSpinBox, QScrollArea, QGridLayout,
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QFileDialog, QMessageBox, QSpinBox, QGridLayout,
     QListWidget, QListWidgetItem
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QImage, QPixmap
+from .zoomable_scroll_area import ZoomableScrollArea
 import fitz
 import os
 
@@ -97,7 +98,7 @@ class PDFRotatorWidget(QWidget):
         preview_label.setAlignment(Qt.AlignCenter)
         
         # 미리보기 스크롤 영역
-        self.scroll_area = QScrollArea()
+        self.scroll_area = ZoomableScrollArea(self.zoom_spin)
         self.scroll_area.setWidgetResizable(True)
         self.scroll_area.setMinimumWidth(400)
         

--- a/src/ui/pdf_to_image.py
+++ b/src/ui/pdf_to_image.py
@@ -1,9 +1,10 @@
 from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton, 
-    QFileDialog, QMessageBox, QSpinBox, QScrollArea, QGridLayout
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QFileDialog, QMessageBox, QSpinBox, QGridLayout
 )
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QImage, QPixmap
+from .zoomable_scroll_area import ZoomableScrollArea
 import fitz
 import os
 
@@ -112,7 +113,7 @@ class PDFToImageWidget(QWidget):
         preview_label.setAlignment(Qt.AlignCenter)
         
         # 미리보기 스크롤 영역
-        self.scroll_area = QScrollArea()
+        self.scroll_area = ZoomableScrollArea(self.zoom_spin)
         self.scroll_area.setWidgetResizable(True)
         self.scroll_area.setMinimumWidth(400)
         


### PR DESCRIPTION
## Summary
- use `ZoomableScrollArea` for all PDF preview panels
- add zoom spin control to image extractor for scaling
- remove unused `QScrollArea` import

## Testing
- `python -m py_compile src/ui/pdf_to_image.py src/ui/pdf_rotator.py src/ui/pdf_image_extractor.py src/ui/pdf_formula_extractor.py`
- `python -m py_compile src/ui/*.py src/utils/*.py`