### PR TITLE
Refactor PDF formatter tab UI with preview

### DIFF
--- a/src/ui/pdf_formatter_tab.py
+++ b/src/ui/pdf_formatter_tab.py
@@ -1,8 +1,12 @@
-from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QPushButton, 
-                           QFileDialog, QLabel, QProgressBar)
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QFileDialog, QProgressBar, QSpinBox, QGridLayout
+)
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QDragEnterEvent, QDropEvent
+from PyQt5.QtGui import QDragEnterEvent, QDropEvent, QImage, QPixmap
 from PyPDF2 import PdfReader, PdfWriter
+from .zoomable_scroll_area import ZoomableScrollArea
+import fitz
 import os
 
 class DropArea(QLabel):
@@ -66,41 +70,93 @@ class DropArea(QLabel):
 class PdfFormatterTab(QWidget):
     def __init__(self):
         super().__init__()
-        self.initUI()
-        
-    def initUI(self):
+        self.current_doc = None
+        self.converted_doc = None
+        self.setup_ui()
+
+    def setup_ui(self):
+        main_layout = QHBoxLayout()
+
+        left_panel = self.setup_left_panel()
+        right_panel = self.setup_right_panel()
+
+        main_layout.addLayout(left_panel, stretch=1)
+        main_layout.addLayout(right_panel, stretch=2)
+
+        self.setLayout(main_layout)
+
+    def setup_left_panel(self):
         layout = QVBoxLayout()
-        
+
         # 드래그 앤 드롭 영역
         self.dropArea = DropArea(self)
         self.dropArea.mousePressEvent = self.selectFile  # 클릭으로도 파일 선택 가능
-        
+
         # 선택된 파일 경로 표시
         self.fileLabel = QLabel('선택된 파일: 없음')
-        
+        self.fileLabel.setWordWrap(True)
+
+        # 미리보기 배율
+        zoom_layout = QGridLayout()
+        self.zoom_spin = QSpinBox()
+        self.zoom_spin.setRange(10, 300)
+        self.zoom_spin.setValue(30)
+        self.zoom_spin.setSuffix('%')
+        self.zoom_spin.valueChanged.connect(self.update_preview)
+        zoom_layout.addWidget(QLabel('미리보기 배율:'), 0, 0)
+        zoom_layout.addWidget(self.zoom_spin, 0, 1)
+
         # 변환 버튼
         self.convertButton = QPushButton('A4 형식으로 변환')
         self.convertButton.clicked.connect(self.convertToA4)
         self.convertButton.setEnabled(False)
-        
+
         # 진행 상태바
         self.progressBar = QProgressBar()
         self.progressBar.setVisible(False)
-        
-        # 위젯 배치
+
         layout.addWidget(self.dropArea)
         layout.addWidget(self.fileLabel)
+        layout.addLayout(zoom_layout)
         layout.addWidget(self.convertButton)
         layout.addWidget(self.progressBar)
-        
-        self.setLayout(layout)
+        layout.addStretch()
+
+        return layout
+
+    def setup_right_panel(self):
+        layout = QVBoxLayout()
+
+        preview_label = QLabel('미리보기')
+        preview_label.setAlignment(Qt.AlignCenter)
+
+        self.scroll_area = ZoomableScrollArea(self.zoom_spin)
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setMinimumWidth(400)
+
+        self.preview_container = QWidget()
+        self.preview_layout = QVBoxLayout(self.preview_container)
+        self.scroll_area.setWidget(self.preview_container)
+
+        layout.addWidget(preview_label)
+        layout.addWidget(self.scroll_area)
+
+        return layout
 
     def handleDroppedFile(self, file_path):
         if file_path.lower().endswith('.pdf'):
             self.selected_file = file_path
-            self.fileLabel.setText(f'선택된 파일: {file_path}')
+            self.fileLabel.setText(f'선택된 파일: {os.path.basename(file_path)}')
             self.convertButton.setEnabled(True)
             self.dropArea.setText('PDF 파일이 선택되었습니다\n다른 파일을 드래그하여 변경할 수 있습니다')
+
+            # 기존 문서가 있으면 닫기
+            if self.current_doc:
+                self.current_doc.close()
+
+            self.current_doc = fitz.open(file_path)
+            self.converted_doc = None
+            self.update_preview()
 
     def selectFile(self, event=None):
         fname, _ = QFileDialog.getOpenFileName(self, '파일 선택', '', 
@@ -172,11 +228,65 @@ class PdfFormatterTab(QWidget):
                 
                 with open(save_path, 'wb') as output_file:
                     writer.write(output_file)
-                    
+
                 self.fileLabel.setText(f'변환 완료! 저장 위치: {save_path}')
                 self.dropArea.setText('여기에 PDF 파일을 드래그하세요\n또는 클릭하여 파일을 선택하세요')
+
+                if self.converted_doc:
+                    self.converted_doc.close()
+                self.converted_doc = fitz.open(save_path)
+                self.update_preview()
                 
             except Exception as e:
                 self.fileLabel.setText(f'오류 발생: {str(e)}')
             finally:
-                self.progressBar.setVisible(False) 
+                self.progressBar.setVisible(False)
+
+    def update_preview(self):
+        if not self.current_doc:
+            return
+
+        for i in reversed(range(self.preview_layout.count())):
+            widget = self.preview_layout.itemAt(i).widget()
+            if widget:
+                widget.setParent(None)
+
+        zoom = self.zoom_spin.value() / 100
+
+        self.preview_layout.addWidget(QLabel('변환 전'))
+        for page_num in range(self.current_doc.page_count):
+            page = self.current_doc[page_num]
+            pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom))
+            img = QImage(pix.samples, pix.width, pix.height, pix.stride, QImage.Format_RGB888)
+            pixmap = QPixmap.fromImage(img)
+            label = QLabel()
+            label.setPixmap(pixmap)
+            label.setAlignment(Qt.AlignCenter)
+            page_label = QLabel(f'페이지 {page_num + 1}')
+            page_label.setAlignment(Qt.AlignCenter)
+            self.preview_layout.addWidget(page_label)
+            self.preview_layout.addWidget(label)
+            self.preview_layout.addWidget(QLabel(''))
+
+        if self.converted_doc:
+            self.preview_layout.addWidget(QLabel('변환 후'))
+            for page_num in range(self.converted_doc.page_count):
+                page = self.converted_doc[page_num]
+                pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom))
+                img = QImage(pix.samples, pix.width, pix.height, pix.stride, QImage.Format_RGB888)
+                pixmap = QPixmap.fromImage(img)
+                label = QLabel()
+                label.setPixmap(pixmap)
+                label.setAlignment(Qt.AlignCenter)
+                page_label = QLabel(f'페이지 {page_num + 1}')
+                page_label.setAlignment(Qt.AlignCenter)
+                self.preview_layout.addWidget(page_label)
+                self.preview_layout.addWidget(label)
+                self.preview_layout.addWidget(QLabel(''))
+
+    def closeEvent(self, event):
+        if self.current_doc:
+            self.current_doc.close()
+        if self.converted_doc:
+            self.converted_doc.close()
+        super().closeEvent(event)


### PR DESCRIPTION
## Summary
- update `PdfFormatterTab` to use left/right panel layout
- allow zoomable preview of documents before and after conversion

## Testing
- `python -m py_compile src/ui/pdf_formatter_tab.py`