### PR TITLE
Apply Apple inspired light theme

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,29 +5,29 @@ from PyQt5.QtCore import Qt
 from src.ui.main_window import MainWindow
 
 
-def apply_dark_theme(app: QApplication) -> None:
-    """Apply a simple dark theme for a modern look."""
+def apply_light_theme(app: QApplication) -> None:
+    """Apply a light theme inspired by Apple's design."""
     app.setStyle("Fusion")
 
     palette = QPalette()
-    palette.setColor(QPalette.Window, QColor(53, 53, 53))
-    palette.setColor(QPalette.WindowText, Qt.white)
-    palette.setColor(QPalette.Base, QColor(25, 25, 25))
-    palette.setColor(QPalette.AlternateBase, QColor(53, 53, 53))
-    palette.setColor(QPalette.ToolTipBase, Qt.white)
-    palette.setColor(QPalette.ToolTipText, Qt.white)
-    palette.setColor(QPalette.Text, Qt.white)
-    palette.setColor(QPalette.Button, QColor(53, 53, 53))
-    palette.setColor(QPalette.ButtonText, Qt.white)
+    palette.setColor(QPalette.Window, QColor(242, 242, 247))
+    palette.setColor(QPalette.WindowText, Qt.black)
+    palette.setColor(QPalette.Base, QColor(255, 255, 255))
+    palette.setColor(QPalette.AlternateBase, QColor(242, 242, 247))
+    palette.setColor(QPalette.ToolTipBase, Qt.black)
+    palette.setColor(QPalette.ToolTipText, Qt.black)
+    palette.setColor(QPalette.Text, Qt.black)
+    palette.setColor(QPalette.Button, QColor(242, 242, 247))
+    palette.setColor(QPalette.ButtonText, Qt.black)
     palette.setColor(QPalette.BrightText, Qt.red)
-    palette.setColor(QPalette.Link, QColor(42, 130, 218))
-    palette.setColor(QPalette.Highlight, QColor(42, 130, 218))
-    palette.setColor(QPalette.HighlightedText, Qt.black)
+    palette.setColor(QPalette.Link, QColor(0, 122, 255))
+    palette.setColor(QPalette.Highlight, QColor(0, 122, 255))
+    palette.setColor(QPalette.HighlightedText, Qt.white)
     app.setPalette(palette)
 
 def main():
     app = QApplication(sys.argv)
-    apply_dark_theme(app)
+    apply_light_theme(app)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/src/ui/pdf_formatter_tab.py
+++ b/src/ui/pdf_formatter_tab.py
@@ -16,13 +16,13 @@ class DropArea(QLabel):
         self.setText('\n\n여기에 PDF 파일을 드래그하세요\n또는 클릭하여 파일을 선택하세요')
         self.setStyleSheet('''
             QLabel {
-                border: 2px dashed #aaa;
+                border: 2px dashed #d1d1d6;
                 border-radius: 5px;
-                background-color: #f0f0f0;
+                background-color: #f2f2f7;
                 padding: 20px;
             }
             QLabel:hover {
-                background-color: #e0e0e0;
+                background-color: #e5e5ea;
             }
         ''')
         self.setAcceptDrops(True)
@@ -32,9 +32,9 @@ class DropArea(QLabel):
             event.acceptProposedAction()
             self.setStyleSheet('''
                 QLabel {
-                    border: 2px dashed #4CAF50;
+                    border: 2px dashed #34c759;
                     border-radius: 5px;
-                    background-color: #E8F5E9;
+                    background-color: #e9f9eb;
                     padding: 20px;
                 }
             ''')
@@ -42,13 +42,13 @@ class DropArea(QLabel):
     def dragLeaveEvent(self, event):
         self.setStyleSheet('''
             QLabel {
-                border: 2px dashed #aaa;
+                border: 2px dashed #d1d1d6;
                 border-radius: 5px;
-                background-color: #f0f0f0;
+                background-color: #f2f2f7;
                 padding: 20px;
             }
             QLabel:hover {
-                background-color: #e0e0e0;
+                background-color: #e5e5ea;
             }
         ''')
 
@@ -57,13 +57,13 @@ class DropArea(QLabel):
         self.parent().handleDroppedFile(file_path)
         self.setStyleSheet('''
             QLabel {
-                border: 2px dashed #aaa;
+                border: 2px dashed #d1d1d6;
                 border-radius: 5px;
-                background-color: #f0f0f0;
+                background-color: #f2f2f7;
                 padding: 20px;
             }
             QLabel:hover {
-                background-color: #e0e0e0;
+                background-color: #e5e5ea;
             }
         ''')
 

--- a/src/ui/pdf_rotator.py
+++ b/src/ui/pdf_rotator.py
@@ -158,10 +158,10 @@ class PDFRotatorWidget(QWidget):
             if page_num in self.selected_pages:
                 page_container.setStyleSheet("""
                     QWidget {
-                        border: 2px solid #007bff;
+                        border: 2px solid #007aff;
                         border-radius: 5px;
                         padding: 5px;
-                        background-color: #f8f9fa;
+                        background-color: #f2f2f7;
                     }
                 """)
             
@@ -184,7 +184,7 @@ class PDFRotatorWidget(QWidget):
             
             # 선택 상태 표시
             if page_num in self.selected_pages:
-                info_label.setStyleSheet("background-color: #e3f2fd; color: #007bff;")
+                info_label.setStyleSheet("background-color: #e5f0ff; color: #007aff;")
             
             # 클릭 이벤트 처리
             label.mousePressEvent = lambda e, p=page_num: self.toggle_page_selection(p)

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,13 +1,15 @@
 :root {
-  --primary-color: #007bff;
-  --secondary-color: #6c757d;
-  --background-color: #ffffff;
-  --text-color: #333333;
+  /* Apple inspired light palette */
+  --primary-color: #007aff;
+  --secondary-color: #8e8e93;
+  --background-color: #f2f2f7;
+  --text-color: #000000;
 }
 
 [data-theme="dark"] {
-  --primary-color: #0056b3;
-  --secondary-color: #545b62;
-  --background-color: #1a1a1a;
+  /* Dark mode variant matching Apple style */
+  --primary-color: #0a84ff;
+  --secondary-color: #8e8e93;
+  --background-color: #1c1c1e;
   --text-color: #ffffff;
-} 
+}


### PR DESCRIPTION
## Summary
- restyle CSS variables with Apple-like palette
- update PyQt palette to bright Apple theme
- tweak rotator preview selection styling
- update drag-and-drop styles for formatter tab

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`